### PR TITLE
Parser improvements, fixes #7 (partially).

### DIFF
--- a/minblur_lib/src/builtin_macros/eval_macro.rs
+++ b/minblur_lib/src/builtin_macros/eval_macro.rs
@@ -98,17 +98,17 @@ mod parse {
         common::{macros::prcall, string_cache::StringCache},
         parser::{
             common::{assert_input_consumed, MyResult, Span},
-            parse_instruction_value_const,
+            parse_instruction_value_const, ParseContext,
         },
     };
 
     pub struct Parser {
-        string_cache: StringCache,
+        ctx: ParseContext,
     }
     impl<'a> Parser {
         pub fn new(string_cache: &StringCache) -> Self {
             Self {
-                string_cache: string_cache.clone(),
+                ctx: ParseContext::new(string_cache.clone()),
             }
         }
 
@@ -117,7 +117,7 @@ mod parse {
         }
 
         pub fn next_value_piece(&self, input: Span<'a>) -> MyResult<'a, PieceData<'a>> {
-            let (input, value) = parse_instruction_value_const(&self.string_cache, input)?;
+            let (input, value) = parse_instruction_value_const(&self.ctx, input)?;
             Ok((input, PieceData::InstValue(value)))
         }
 

--- a/minblur_lib/src/builtin_macros/math_macro/mod.rs
+++ b/minblur_lib/src/builtin_macros/math_macro/mod.rs
@@ -78,8 +78,8 @@ mod parse {
     use super::statement::{AssignmentOp, Expression, MathOp};
     use super::*;
     use crate::parser::common::{
-        identifier_basic, match_identifier_basic_const, parse_identifier_basic_const,
-        statement_end, MyResult, Span,
+        identifier_mlog, match_identifier_basic_const, parse_identifier_basic_const, statement_end,
+        MyResult, Span,
     };
 
     pub struct Parser {}
@@ -119,7 +119,7 @@ mod parse {
             terminated(parse_identifier_basic_const, pair(space0, tag(":")))
                 .map(|name| LabelStatement {
                     pos: Position::from_span(&input),
-                    name: name.to_string(),
+                    name,
                 })
                 .parse(input)
         }
@@ -183,7 +183,7 @@ mod parse {
     }
 
     fn expr_parser() -> impl IExpressionParser<MathOp> {
-        ExpressionParser::new(match_identifier_basic_const, identifier_basic)
+        ExpressionParser::new(match_identifier_basic_const, identifier_mlog)
     }
 }
 

--- a/minblur_lib/src/builtin_macros/math_macro/statement.rs
+++ b/minblur_lib/src/builtin_macros/math_macro/statement.rs
@@ -209,6 +209,7 @@ impl MathFunction {
             Self::Op(v) => v.name(),
         }
     }
+
     pub fn from_name(input: &str) -> Option<Self> {
         // diallow op and set instructions
         match input {
@@ -219,10 +220,8 @@ impl MathFunction {
         }
         if let Some(op) = OpFunction::from_name(input) {
             Some(Self::Op(op))
-        } else if let Some(instr) = InstructionKind::from_name(input) {
-            Some(Self::Instruction(instr))
         } else {
-            None
+            InstructionKind::from_name(input).map(Self::Instruction)
         }
     }
 }

--- a/minblur_lib/src/compiler/instruction.rs
+++ b/minblur_lib/src/compiler/instruction.rs
@@ -90,19 +90,10 @@ impl InstValue {
         matches!(self, Self::Const(_) | Self::QuickConstExpr(_, _))
     }
 
-    /// Returns true iff this value is a name (NOT an enum name)
-    pub fn is_name(&self) -> bool {
-        matches!(self, Self::Value(AValue::Name(_)))
-    }
-
     pub fn is_concrete(&self) -> bool {
         matches!(self, Self::Value(_) | Self::EnumName(_))
     }
 
-    /// Returns true iff this value is a number
-    pub fn is_number(&self) -> bool {
-        matches!(self, Self::Value(AValue::Num(_)))
-    }
     /// Returns true iff this value is a quoted string
     pub fn is_string(&self) -> bool {
         matches!(self, Self::Value(AValue::String(_)))
@@ -335,11 +326,11 @@ macro_rules! value_check {
         )
     };
 
-    (@check $field:expr; { is_name() }) => { $field.is_name() };
+    (@check $field:expr; { is_name() }) => { $field.as_name().is_some() };
     (@error $field:expr; { is_name() }) => { "name" };
     (@check $field:expr; { is_enum<$enum_type:ty>() }) => { $field.as_enum::<$enum_type>().is_some() };
     (@error $field:expr; { is_enum<$enum_type:ty>() }) => { stringify!(enum $enum_type) };
-    (@check $field:expr; { is_number() }) => { $field.is_number() };
+    (@check $field:expr; { is_number() }) => { $field.as_number().is_some() };
     (@error $field:expr; { is_number() }) => { "number" };
     (@check $field:expr; { is_string() }) => { $field.is_string() };
     (@error $field:expr; { is_string() }) => { "string" };
@@ -1237,6 +1228,7 @@ crate::build_enum_match! {
         UnitLocate: (8, false),
     }
 }
+pub(crate) use instruction_kind_match;
 
 impl InstructionKind {
     pub fn create(&self) -> Instruction {

--- a/minblur_lib/src/compiler/mod.rs
+++ b/minblur_lib/src/compiler/mod.rs
@@ -161,6 +161,21 @@ mod test {
     }
 
     #[test]
+    fn wrong_arg_count() {
+        let code = " set a 1 2";
+        assert_eq!(compile_error_display(code), "Error in test\n| syntax error at 1:2 near 's' => expected label, instruction, or directive\n|   at 1:2 near 's' => instruction has incorrect number of arguments\n");
+    }
+
+    #[test]
+    fn wrong_math_arg_count() {
+        let code = "m! control(1, 2)";
+        assert_eq!(
+            compile_error_display(code),
+            "Error in test at 1:1\n| function 'control' failed => \"expected 6 args, got 2\"\n\n"
+        );
+    }
+
+    #[test]
     fn test_local_labels() {
         let code = r#"
         .macro to_max(max)

--- a/minblur_lib/src/parser/mod.rs
+++ b/minblur_lib/src/parser/mod.rs
@@ -6,5 +6,6 @@ mod token;
 
 pub use source::{ArcSource, Source};
 pub use statement::*;
-pub use token::instruction::{parse_instruction_arg_string, parse_instruction_value_const};
-pub use token::TokenParser;
+pub use token::{
+    parse_instruction_arg_string, parse_instruction_value_const, ParseContext, TokenParser,
+};

--- a/minblur_lib/src/parser/snapshots/minblur_lib__parser__token__test__multiline_basic.snap
+++ b/minblur_lib/src/parser/snapshots/minblur_lib__parser__token__test__multiline_basic.snap
@@ -1,6 +1,6 @@
 ---
 source: minblur_lib/src/parser/token.rs
-assertion_line: 342
+assertion_line: 473
 expression: out
 
 ---
@@ -35,8 +35,8 @@ expression: out
         data: Instruction(
             Set(
                 InstructionSet {
-                    result: Value(
-                        Name(
+                    result: EnumName(
+                        CaString(
                             "r1",
                         ),
                     ),
@@ -70,13 +70,13 @@ expression: out
                             "add",
                         ),
                     ),
-                    result: Value(
-                        Name(
+                    result: EnumName(
+                        CaString(
                             "r2",
                         ),
                     ),
-                    left: Value(
-                        Name(
+                    left: EnumName(
+                        CaString(
                             "r1",
                         ),
                     ),
@@ -130,13 +130,13 @@ expression: out
                             "mul",
                         ),
                     ),
-                    result: Value(
-                        Name(
+                    result: EnumName(
+                        CaString(
                             "y",
                         ),
                     ),
-                    left: Value(
-                        Name(
+                    left: EnumName(
+                        CaString(
                             "r1",
                         ),
                     ),


### PR DESCRIPTION
Most of this commit is refactoring the instruction parsing code to make it less brittle and pave the way for future improvements. Truly improved error messages will require a custom nom error type, but this should suffice for now.

This also includes several clippy fixes, more tests, the usual.